### PR TITLE
관리자페이지 : 이벤트 컴포넌트 스타일 수정, 유저의 마지막 로그인 일자 표시 기능 추가 (수정)

### DIFF
--- a/src/api/log.js
+++ b/src/api/log.js
@@ -75,3 +75,20 @@ export function putPointLogRollback(params) {
 export function putWarningLogRollback(params) {
   return axios.put(`${PREFIX_URL}/warning/rollback?logId=${params.id}`);
 }
+
+/**
+ * 전체 포인트 로그를 페이징 조회한다
+ * @param params { page, size }
+ */
+
+export function getAllPointLogByPage(params) {
+  return axios.get(
+    `${PREFIX_URL}/point/all/page?page=${params.page}&size=${params.size}`,
+  );
+}
+
+export function getAllWarningLogByPage(params) {
+  return axios.get(
+    `${PREFIX_URL}/warning/all/page?page=${params.page}&size=${params.size}`,
+  );
+}

--- a/src/api/user.js
+++ b/src/api/user.js
@@ -129,3 +129,10 @@ export function rerollRandomProblem(params) {
 export function getAllUsersNotionIds() {
   return axios.get(`${PREFIX_URL}/mention/list`);
 }
+
+/**
+ * 모든 유저들의 마지막 로그인 일시를 조회한다.
+ */
+export function getAllUserLastLogin() {
+  return axios.get(`${PREFIX_URL}/log/login`);
+}

--- a/src/pages/Admin/LastLogin/index.jsx
+++ b/src/pages/Admin/LastLogin/index.jsx
@@ -1,0 +1,307 @@
+import { getAllUserLastLogin } from 'api/user';
+import useFetch from 'hooks/useFetch';
+import React, { useCallback, useState } from 'react';
+import {
+  Card,
+  Content,
+  LastLoginDate,
+  ScrollButton,
+  Title,
+  User,
+  UserWrapper,
+} from './style';
+import useScroll from 'hooks/useScroll';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
+import { CommonProfileImage } from 'style/commonStyle';
+import { format } from 'highcharts';
+import dayjs from 'dayjs';
+
+function LastLogin() {
+  //const [users, reFetch] = useFetch(getAllUserLastLogin, []);
+  const users = [
+    {
+      bojHandle: 'asdf016182',
+      notionId: 'klloo',
+      emoji: '🏖️',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/asdf016182-picture-1683285947529.png',
+      lastLoginDate: '2023-10-08T19:18:52',
+    },
+    {
+      bojHandle: 'taipaise',
+      notionId: '이동현',
+      emoji: '🐾',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/taipaise-picture-1683633399462.png',
+      lastLoginDate: '2023-10-06T19:18:52',
+    },
+    {
+      bojHandle: 'chltjwl22',
+      notionId: '최서지',
+      emoji: '🥑',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/chltjwl22-picture-1682353272947.png',
+      lastLoginDate: '2023-10-07T19:18:52',
+    },
+    {
+      bojHandle: 'choish20',
+      notionId: '최승헌',
+      emoji: '🍞',
+      profileImg: 'null',
+      lastLoginDate: '2023-10-08T10:18:52',
+    },
+    {
+      bojHandle: 'mathpaul3',
+      notionId: 'Paul Eom',
+      emoji: '🦊',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/mathpaul3-picture-1645474246687.png',
+      lastLoginDate: '2023-10-08T19:22:52',
+    },
+    {
+      bojHandle: 'dkssudgkgl',
+      notionId: '은정 방',
+      emoji: '✱',
+      profileImg: 'null',
+      lastLoginDate: '2023-10-08T19:23:52',
+    },
+    {
+      bojHandle: 'jin20fd',
+      notionId: '성유진',
+      emoji: '💫',
+      profileImg: 'null',
+      lastLoginDate: '2023-10-08T19:18:55',
+    },
+    {
+      bojHandle: 'ss001015',
+      notionId: 'RubyTubi',
+      emoji: '✏️',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/ss001015-picture-1673075526199.png',
+      lastLoginDate: '2023-10-08T19:18:51',
+    },
+    {
+      bojHandle: 'hdaisywd',
+      notionId: 'Dahee Hong',
+      emoji: '☃️',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/hdaisywd-picture-1688838721986.png',
+      lastLoginDate: '2023-10-05T19:18:52',
+    },
+    {
+      bojHandle: 'angrypig7',
+      notionId: 'Kihun Song',
+      emoji: '🐴',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/angrypig7-picture-1693720421238.png',
+      lastLoginDate: '2023-10-05T11:18:52',
+    },
+    {
+      bojHandle: 'wlgh1553',
+      notionId: '이지호',
+      emoji: '🐸',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/wlgh1553-picture-1693238818895.png',
+      lastLoginDate: '2023-10-08T19:33:52',
+    },
+    {
+      bojHandle: 'choidg33',
+      notionId: '최다경',
+      emoji: '🍎',
+      profileImg: 'null',
+      lastLoginDate: '2023-10-08T12:13:52',
+    },
+    {
+      bojHandle: 'phd0801',
+      notionId: '박성근',
+      emoji: '？',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/phd0801-picture-1684033267569.png',
+      lastLoginDate: '2023-10-03T19:13:52',
+    },
+    {
+      bojHandle: 'testUser',
+      notionId: 'testUser',
+      emoji: '😊',
+      profileImg: '',
+      lastLoginDate: '2023-10-01T19:15:52',
+    },
+    {
+      bojHandle: 'testUser3',
+      notionId: 'testUser3',
+      emoji: '😂',
+      profileImg: '',
+      lastLoginDate: '2023-10-05T15:15:52',
+    },
+    {
+      bojHandle: 'enough',
+      notionId: 'cool',
+      emoji: '👌',
+      profileImg: '',
+      lastLoginDate: '2023-10-01T11:18:51',
+    },
+    {
+      bojHandle: "that'sOK",
+      notionId: "WowThat'sCool",
+      emoji: '🆒',
+      profileImg: '',
+      lastLoginDate: '2023-10-03T13:12:52',
+    },
+    {
+      bojHandle: 'before',
+      notionId: 'before',
+      emoji: '🎶',
+      profileImg: '',
+      lastLoginDate: '2023-10-02T11:15:52',
+    },
+    {
+      bojHandle: 'melonboy',
+      notionId: 'Minboy',
+      emoji: '🐧',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/melonboy-picture-1668514629916.png',
+      lastLoginDate: '2023-10-05T19:15:55',
+    },
+    {
+      bojHandle: 'seyeon0207',
+      notionId: 'Seyeon Yang',
+      emoji: '🐇',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/seyeon0207-picture-1693277390147.png',
+      lastLoginDate: '2023-10-08T15:11:51',
+    },
+    {
+      bojHandle: 'seoheo',
+      notionId: 'SY Heo',
+      emoji: '🚀',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/seoheo-picture-1679724776174.png',
+      lastLoginDate: '2023-10-03T19:15:52',
+    },
+    {
+      bojHandle: 'eogns47',
+      notionId: 'KangManJoo',
+      emoji: '🐱',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/eogns47-picture-1673158646823.png',
+      lastLoginDate: '2023-10-08T20:11:52',
+    },
+    {
+      bojHandle: 'seyjang',
+      notionId: 'sayyoung',
+      emoji: '🍀',
+      profileImg: 'null',
+      lastLoginDate: '2023-09-29T19:18:52',
+    },
+    {
+      bojHandle: 'hyeonjinan096',
+      notionId: 'hyeon200',
+      emoji: '🍡',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/hyeonjinan096-picture-1681571796304.png',
+      lastLoginDate: '2023-10-01T19:08:52',
+    },
+    {
+      bojHandle: 'jake0104',
+      notionId: '재현 주',
+      emoji: '🍷',
+      profileImg: 'null',
+      lastLoginDate: '2023-09-22T12:18:52',
+    },
+    {
+      bojHandle: 'emforhs0315',
+      notionId: '성훈 조',
+      emoji: '👍',
+      profileImg:
+        'https://static.solved.ac/uploads/profile/emforhs0315-picture-1694405066664.png',
+      lastLoginDate: '2023-10-08T20:18:53',
+    },
+  ];
+
+  const [sortedUsers, setSortedusers] = useState(
+    [...users].sort((a, b) => {
+      const dateA = a.lastLoginDate
+        ? new Date(a.lastLoginDate)
+        : new Date('1999-01-01T00:00:00');
+      const dateB = b.lastLoginDate
+        ? new Date(b.lastLoginDate)
+        : new Date('1999-01-01T00:00:00');
+      return dateB - dateA;
+    }),
+  );
+
+  const [
+    leftArrowHovering,
+    rightArrowHovering,
+    setArrowHovering,
+    horizontalScrollRef,
+    handleNextButtonClick,
+  ] = useScroll();
+  const onClickProfileImg = useCallback((e, bojHandle) => {
+    e.preventDefault();
+    const url = `https://solved.ac/profile/${bojHandle}`;
+    window.open(url, '_blank');
+  }, []);
+
+  return (
+    <Card>
+      <Title>마지막 로그인 일시</Title>
+      <Content>
+        <UserWrapper ref={horizontalScrollRef}>
+          {sortedUsers.map((user) => (
+            <User key={user.notionId}>
+              <div>
+                {user.notionId} {user.emoji}
+              </div>
+              <CommonProfileImage
+                width="50"
+                height="50"
+                src={
+                  user.profileImg != 'null'
+                    ? user.profileImg
+                    : 'https://static.solved.ac/misc/360x360/default_profile.png'
+                }
+                onClick={(e) => onClickProfileImg(e, user.bojHandle)}
+                style={{ cursor: 'pointer' }}
+              ></CommonProfileImage>
+              <LastLoginDate>
+                {dayjs(user.lastLoginDate).format('YYYY/MM/DD\nHH:mm:ss')}
+              </LastLoginDate>
+            </User>
+          ))}
+        </UserWrapper>
+        <ScrollButton
+          onClick={() => {
+            handleNextButtonClick('prev');
+          }}
+          onMouseOver={() => setArrowHovering('prev', true)}
+          onMouseOut={() => setArrowHovering('prev', false)}
+          type="prev"
+        >
+          {leftArrowHovering && (
+            <div>
+              <FaChevronLeft />
+            </div>
+          )}
+        </ScrollButton>
+        <ScrollButton
+          onClick={() => {
+            handleNextButtonClick('next');
+            console.log(sortedUsers);
+          }}
+          onMouseOver={() => setArrowHovering('next', true)}
+          onMouseOut={() => setArrowHovering('next', false)}
+          type="next"
+        >
+          {rightArrowHovering && (
+            <div>
+              <FaChevronRight />
+            </div>
+          )}
+        </ScrollButton>
+      </Content>
+    </Card>
+  );
+}
+
+export default LastLogin;

--- a/src/pages/Admin/LastLogin/index.jsx
+++ b/src/pages/Admin/LastLogin/index.jsx
@@ -17,8 +17,8 @@ import { format } from 'highcharts';
 import dayjs from 'dayjs';
 
 function LastLogin() {
-  //const [users, reFetch] = useFetch(getAllUserLastLogin, []);
-  const users = [
+  const [users, reFetch] = useFetch(getAllUserLastLogin, []);
+  /*const users = [
     {
       bojHandle: 'asdf016182',
       notionId: 'klloo',
@@ -216,7 +216,7 @@ function LastLogin() {
         'https://static.solved.ac/uploads/profile/emforhs0315-picture-1694405066664.png',
       lastLoginDate: '2023-10-08T20:18:53',
     },
-  ];
+  ];*/
 
   const [sortedUsers, setSortedusers] = useState(
     [...users].sort((a, b) => {

--- a/src/pages/Admin/LastLogin/style.jsx
+++ b/src/pages/Admin/LastLogin/style.jsx
@@ -1,0 +1,66 @@
+import styled from '@emotion/styled';
+import { CommonCard } from 'style/commonStyle';
+export const Card = styled(CommonCard)`
+  position: relative;
+  flex-wrap: nowrap;
+  padding: 20px 0 20px 0;
+`;
+
+export const UserWrapper = styled.div`
+  margin-left: 10px;
+  margin-right: 10px;
+  display: flex;
+  overflow-x: auto;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+export const Content = styled.div`
+  position: relative;
+  display: flex;
+`;
+
+export const User = styled.div`
+  width: 130px;
+  display: flex;
+  flex: 0 0 auto;
+  padding: 10px 0 10px 0;
+  flex-direction: column;
+  align-items: center;
+  font-weight: bold;
+  font: 0.9rem;
+  & div {
+    margin-bottom: 20px;
+  }
+`;
+
+export const Title = styled.div`
+  position: relative;
+  top: 0;
+  left: 0;
+  font-weight: bold;
+  margin-bottom: 25px;
+  padding-left: 25px;
+`;
+
+export const ScrollButton = styled.button`
+  border: none;
+  position: absolute;
+  background: transparent;
+  text-align: center;
+  cursor: pointer;
+  z-index: 999;
+  right: ${(props) => (props.type == 'next' ? '0' : '')};
+  left: ${(props) => (props.type == 'prev' ? '0' : '')};
+  height: 80px;
+  & div {
+    color: #b6b6b6;
+  }
+`;
+
+export const LastLoginDate = styled.div`
+  font-size: 1px;
+`;

--- a/src/pages/Admin/PointEvent/index.jsx
+++ b/src/pages/Admin/PointEvent/index.jsx
@@ -95,8 +95,8 @@ function PointEvent() {
         </Event>
         {events.map((event) => {
           return (
-            <>
-              <Event key={event.id}>
+            <div key={event.id}>
+              <Event>
                 <TextWrapper>
                   <Id>{event.id}</Id>
                   <Name>{event.eventName}</Name>
@@ -106,7 +106,7 @@ function PointEvent() {
                 <EventDescription>{event.description}</EventDescription>
                 <Value>x{event.percentage}</Value>
               </Event>
-            </>
+            </div>
           );
         })}
       </EventWrapper>

--- a/src/pages/Admin/PointEvent/index.jsx
+++ b/src/pages/Admin/PointEvent/index.jsx
@@ -51,7 +51,7 @@ function PointEvent() {
   const [events, reFetchEvents] = useFetch(getAllPointEvents, []);
 
   return (
-    <Card>
+    <Card eventCnt={events.length}>
       <TitleWrapper>
         <Title>포인트 이벤트</Title>
       </TitleWrapper>

--- a/src/pages/Admin/PointEvent/style.jsx
+++ b/src/pages/Admin/PointEvent/style.jsx
@@ -3,6 +3,8 @@ import { CommonCard } from 'style/commonStyle';
 
 export const Card = styled(CommonCard)`
   padding: 20px;
+  height: ${(props) =>
+    props.eventCnt > 10 ? '800px' : `${160.4 + 63.4 * props.eventCnt + 25}px`};
 `;
 
 export const Title = styled.div`
@@ -72,8 +74,7 @@ export const Event = styled.div`
   justify-content: space-between;
   margin-bottom: 25px;
   width: 100%;
-  //text-decoration: ${(props) => (props.state ? '' : 'line-through')};
-  //text-decoration-color: var(--color-textgrey);
+  height: auto;
 `;
 
 export const EventDescription = styled.div`

--- a/src/pages/Admin/index.jsx
+++ b/src/pages/Admin/index.jsx
@@ -11,6 +11,7 @@ import Modal from 'layouts/Modal';
 import { CommonFlexWrapper, CommonTitle } from 'style/commonStyle';
 import ShowAllUserLogs from './ShowAllUserLogs';
 import PointEvent from './PointEvent';
+import LastLogin from './LastLogin';
 
 function Admin() {
   const [showWarningManageModal, setShowWarningManageModal] = useState(false);
@@ -55,6 +56,7 @@ function Admin() {
         ))}
       </UtilWrapper> */}
       <YesterdayUnsolved />
+      <LastLogin />
       <PointEvent />
       <ShowAllUserLogs />
       <UserManageList />


### PR DESCRIPTION
- 이벤트 컴포넌트의 스타일 수정 : 이벤트 10개부터는 Card의 높이 고정, 이전까지는 이벤트 수에 따라 높이 조절
- 모든 유저들의 마지막 로그인 일자 표시 기능 : 맨 왼쪽부터 시작하여, 가장 최근에 로그인한 유저를 표시함. 오른쪽으로 갈 수록 로그인을 가장 오래전에 한 유저
- 저번이랑 다른거 : 테스트하려고 유저 리스트 직접 만들어 써놨는데 그거 고쳐놓음